### PR TITLE
Adding support for AMD GPUs using sonm/opencl

### DIFF
--- a/Dockerfile.gpu-amd
+++ b/Dockerfile.gpu-amd
@@ -1,0 +1,66 @@
+#FROM ubuntu:18.04
+FROM sonm/opencl
+
+RUN apt-get update
+RUN apt-get install -y wget build-essential
+# build fails unless these are separate apt-get installs - don't consolidate
+RUN apt-get install -y git csh python2.7 python-pip
+RUN pip install requests
+
+#RUN mkdir /client
+
+##### Install MGLtools, which provides some utility scripts we need for both CPU and GPU versions
+##### Need mglTools for both CPU and GPU versions - could make this a base image
+
+RUN wget http://mgltools.scripps.edu/downloads/downloads/tars/releases/REL1.5.6/mgltools_x86_64Linux2_1.5.6.tar.gz
+RUN tar -xvzf mgltools_x86_64Linux2_1.5.6.tar.gz
+#RUN cd /mgltools_x86_64Linux2_1.5.6 ; tar -xvzf MGLToolsPckgs.tar.gz
+RUN cd /mgltools_x86_64Linux2_1.5.6 ; ./install.sh
+#RUN mv mgltools_x86_64Linux2_1.5.6 /mgtools
+
+
+
+
+
+RUN wget http://autodock.scripps.edu/downloads/autodock-registration/tars/dist426/autodocksuite-4.2.6-src.tar.gz
+RUN mkdir /autodock
+RUN cd /autodock ; tar -xvzf /autodocksuite-4.2.6-src.tar.gz
+RUN ls /autodock
+
+RUN cd /autodock/src/autogrid/ ; ./configure ; make ; make install
+RUN cd /autodock/src/autodock/ ; ./configure ; make ; make install
+
+
+
+#RUN apt-get install -y git opencl-c-headers ocl-icd-libopencl1 ocl-icd-opencl-dev
+#RUN apt-get install -y nvidia-opencl-dev nvidia-opencl-icd-384
+
+RUN git clone https://github.com/ccsb-scripps/AutoDock-GPU ; cd AutoDock-GPU ; make DEVICE=GPU NUMWI=32
+RUN cd /AutoDock-GPU ; ls
+RUN ls
+RUN pwd
+RUN cd /model/ ; ls
+
+
+
+COPY requirements.txt /
+RUN pip install -r requirements.txt
+
+
+
+COPY *.py /
+COPY docking /docking/
+COPY *.sh /
+COPY receptors /receptors
+COPY .git /.git
+
+
+
+
+#RUN apt-get install -y git opencl-c-headers ocl-icd-libopencl1 ocl-icd-opencl-dev
+#COPY sars2-docking /model
+#CMD cd /model/ ; /AutoDock-GPU/bin/autodock_gpu_32wi -ffile chainE.maps.fld -lfile DCABRM.xaa_ligand_200.pdbqt -nrun 100
+
+
+ENTRYPOINT ["/quarantine.sh"]
+

--- a/README.md
+++ b/README.md
@@ -27,13 +27,21 @@ This uses the standard version of AutoDock4.
     sudo docker run -it -e ME=anonymous quarantine
 
 ##### GPU users (much faster!) :
-You will need to have nvidia-docker installed. This will run a [GPU-optimized version of Autodock](https://github.com/ccsb-scripps/AutoDock-GPU) 
+This will run a [GPU-optimized version of Autodock](https://github.com/ccsb-scripps/AutoDock-GPU).
+
+###### NVidia
+You will need to have nvidia-docker installed. 
 
     sudo docker build -t quarantinegpu -f Dockerfile.gpu .
     sudo nvidia-docker run -it -e ME=anonymous quarantinegpu
     
 Need nvidia-docker? [this is the best tutorial on how to install it](https://medium.com/@sh.tsang/docker-tutorial-5-nvidia-docker-2-0-installation-in-ubuntu-18-04-cb80f17cac65)
 
+###### AMD
+Build and run using the standard docker.
+
+    sudo docker build -t quarantinegpu -f Dockerfile.gpu-amd .
+    sudo docker run --device /dev/dri -it -e ME=anonymous quarantinegpu
 
 ##### Why Docker ?
 


### PR DESCRIPTION
I added a new file specifically for the AMD GPUs, to spare NVidia users the overhead of downloading AMD drivers. Since the sonm/opencl parent image actually also supports NVidia, maybe a new base image can be created with only AMD drivers. I don't know how to do this, so I left it as is. I also changed the README.md adding the necessary commands.